### PR TITLE
containerfile: use golang builder 1.18

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.16 as builder
+FROM docker.io/golang:1.18 as builder
 ARG GIT_VERSION="(unset)"
 ARG COMMIT_ID="(unset)"
 


### PR DESCRIPTION
Update to the latest version of the golang image.

Signed-off-by: John Mulligan <phlogistonjohn@asynchrono.us>