### PR TITLE
makefile: minor fixes needed to match planned tagging format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 
-COMMIT_ID = $(shell git describe --abbrev=40 --always --dirty=+ 2>/dev/null)
-GIT_VERSION = $(shell git describe --match='v[0-9]*.[0-9].[0-9]' 2>/dev/null || echo "(unset)")
+COMMIT_ID = $(shell git describe --abbrev=40 --always --exclude='*' --dirty=+ 2>/dev/null)
+GIT_VERSION = $(shell git describe --match='v[0-9]*.[0-9]' --match='v[0-9]*.[0-9].[0-9]' 2>/dev/null || echo "(unset)")
 
 # Image URL to use all building/pushing image targets
 TAG ?= latest


### PR DESCRIPTION
We want the makefile to help us embed the version and hash of the git
checkout used for the build. Fix getting the hash when a tag is applied
and when the tag is in the form vX.Y (rather than vX.Y.Z).
