### PR TITLE
improved main

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Executes svcwatch process.
 package main
 
 import (
@@ -21,12 +22,14 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	goruntime "runtime"
 	"syscall"
 
 	flag "github.com/spf13/pflag"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	//"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -36,6 +39,11 @@ import (
 )
 
 var (
+	// Version of the software at compile time.
+	Version = "(unset)"
+	// CommitID in the git revision used at compile time.
+	CommitID = "(unset)"
+
 	destPath      = "/var/lib/svcwatch/status.json"
 	svcLabelKey   = ""
 	svcLabelValue = ""
@@ -81,6 +89,13 @@ func main() {
 		fmt.Printf("failed to set up logger\n")
 		os.Exit(2)
 	}
+
+	l.Info("Initializing service watcher",
+		zap.Any("ProgramName", os.Args[0]),
+		zap.Any("Version", Version),
+		zap.Any("CommitID", CommitID),
+		zap.Any("GoVersion", goruntime.Version()),
+	)
 
 	kubeconfig := os.Getenv("KUBECONFIG")
 	l.Info("Starting service watcher. Params:",

--- a/main.go
+++ b/main.go
@@ -89,7 +89,7 @@ func main() {
 	l, err := zap.NewDevelopment()
 	if err != nil {
 		fmt.Printf("failed to set up logger\n")
-		os.Exit(2)
+		os.Exit(1)
 	}
 
 	l.Info("Initializing service watcher",
@@ -110,7 +110,7 @@ func main() {
 	clientset, err := newClientset()
 	if err != nil {
 		l.Error("failed to create clientset", zap.Error(err))
-		os.Exit(1)
+		os.Exit(2)
 	}
 
 	sel := fmt.Sprintf("%s=%s", svcLabelKey, svcLabelValue)
@@ -119,7 +119,7 @@ func main() {
 		metav1.ListOptions{LabelSelector: sel})
 	if err != nil {
 		l.Error("failed to create watch", zap.Error(err))
-		os.Exit(1)
+		os.Exit(3)
 	}
 
 	errors := make(chan error, 1)

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package service implements service-watch probe
 package service
 
 import (
@@ -67,4 +68,3 @@ func Updated(prev sf.HostState, svc *corev1.Service, nameLabel string) (
 	newh := ToHostState(svc, nameLabel)
 	return newh, prev.Differs(newh)
 }
-

--- a/pkg/statefile/statefile.go
+++ b/pkg/statefile/statefile.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package statefile implements output state as-file
 package statefile
 
 import (


### PR DESCRIPTION
Align `main` conventions with `samba-operator`. 
1) Log version and git-revision early on.
2) Helper function to create clientset.